### PR TITLE
Added static Express routes, grabbed URL path to get project/task ID

### DIFF
--- a/server.js
+++ b/server.js
@@ -46,4 +46,15 @@ app.use('/v1/graphql/project', graphqlHTTP({
   rootValue: projectController,
   graphiql: graphiqlEnabled,
 }));
+
+app.get('/projects/', function (req, res) {
+  res.sendFile('project.html', {"root": __dirname + "/web"});
+});
+app.get('/projects/:projectId', function (req, res) {
+  res.sendFile('project.html', {"root": __dirname + "/web"});
+});
+app.get('/tasks/:taskId', function (req, res) {
+  res.sendFile('task.html', {"root": __dirname + "/web"});
+});
+
 app.listen(process.env.PORT, () => console.log(`Started on port ${process.env.PORT}`));

--- a/web/project.html
+++ b/web/project.html
@@ -1,0 +1,14 @@
+<!doctype HTML>
+<HEAD>
+    <TITLE>
+        Task
+    </TITLE>
+    <SCRIPT src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></SCRIPT>
+</HEAD>
+<BODY>
+    <DIV id="projectId">Loading...</DIV>
+    <SCRIPT>
+        $("#projectId").html(`This URL is ${window.location.pathname}. We can use this to query into Azure Table Storage...`);
+    </SCRIPT>
+</BODY>
+</HTML>

--- a/web/task.html
+++ b/web/task.html
@@ -1,0 +1,14 @@
+<!doctype HTML>
+<HEAD>
+    <TITLE>
+        Task
+    </TITLE>
+    <SCRIPT src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></SCRIPT>
+</HEAD>
+<BODY>
+    <DIV id="taskId">Loading...</DIV>
+    <SCRIPT>
+        $("#taskId").html(`This URL is ${window.location.pathname}. We can use this to query into Azure Table Storage...`);
+    </SCRIPT>
+</BODY>
+</HTML>


### PR DESCRIPTION
Renders simple static HTML page for the following URLs:

- localhost:8080/projects
- localhost:8080/projects/1234
- localhost:8080/tasks/5678

Each page displays text indicating the end of the URL, which can be used to query Azure Table Storage. 

While this isn't the proper Express-y or Vue-y way to do this, it will allow us to prototype without going too far down one particular architecture.